### PR TITLE
Added `destroyData` to callbacks.

### DIFF
--- a/callback-methods.js
+++ b/callback-methods.js
@@ -1,2 +1,2 @@
 module.exports = ['ready', 'readFile', 'writeFile', 'unlink', 'mkdir',
-  'rmdir', 'readdir', 'stat', 'stats', 'lstat', 'access', 'open', 'read', 'write', 'symlink', 'mount', 'unmount', 'getAllMounts', 'close', 'truncate']
+  'rmdir', 'readdir', 'stat', 'stats', 'lstat', 'access', 'open', 'read', 'write', 'symlink', 'mount', 'unmount', 'getAllMounts', 'close', 'truncate', 'destroyData']


### PR DESCRIPTION
Related to https://github.com/mafintosh/hyperdrive/pull/271

This method destroys the data within an archive's storage.