### PR TITLE
Renamed destroyData to destroyStorage

### DIFF
--- a/callback-methods.js
+++ b/callback-methods.js
@@ -1,2 +1,2 @@
 module.exports = ['ready', 'readFile', 'writeFile', 'unlink', 'mkdir',
-  'rmdir', 'readdir', 'stat', 'stats', 'lstat', 'access', 'open', 'read', 'write', 'symlink', 'mount', 'unmount', 'getAllMounts', 'close', 'truncate', 'destroyData']
+  'rmdir', 'readdir', 'stat', 'stats', 'lstat', 'access', 'open', 'read', 'write', 'symlink', 'mount', 'unmount', 'getAllMounts', 'close', 'truncate', 'destroyStorage']


### PR DESCRIPTION
Hey, hyperdrive's API for destroying stored data got renamed from destroyData to destroyStorage.

It'd be nice to have this reflected in the module. 😁