### PR TITLE
Add missing method names for metadata and tags

### DIFF
--- a/callback-methods.js
+++ b/callback-methods.js
@@ -1,2 +1,2 @@
 module.exports = ['ready', 'readFile', 'writeFile', 'unlink', 'mkdir',
-  'rmdir', 'readdir', 'stat', 'stats', 'lstat', 'access', 'open', 'read', 'write', 'symlink', 'mount', 'unmount', 'getAllMounts', 'close', 'truncate', 'destroyStorage', 'clear']
+  'rmdir', 'readdir', 'stat', 'stats', 'lstat', 'access', 'open', 'read', 'write', 'symlink', 'mount', 'unmount', 'getAllMounts', 'close', 'truncate', 'destroyStorage', 'clear', 'setMetadata', 'removeMetadata', 'copy', 'createTag', 'getAllTags', 'deleteTag', 'getTaggedVersion']


### PR DESCRIPTION
Added missing methods for working with metadata and tags.

https://github.com/hypercore-protocol/hyperdrive/blob/master/index.js#L1227